### PR TITLE
added shebang because this is using bash type arrays

### DIFF
--- a/test_clip.sh
+++ b/test_clip.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/bash
+
 export OMP_NUM_THREADS=2
 export TORCH_DISTRIBUTED_DEBUG=INFO
 export TORCH_HOME="./cache/"


### PR DESCRIPTION
`declare -a backbone_sizes=("ViT-B/16" "ViT-L/14")`

This is a bash type syntax, so enforcing a shebang here